### PR TITLE
fix: Update github action to use node 20, required by nestjs 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
           cache: 'yarn'
           registry-url: 'https://registry.npmjs.org'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tawk.to/nestjs-google-pubsub-microservice",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tawk.to/nestjs-google-pubsub-microservice",
-      "version": "6.0.1",
+      "version": "6.0.2",
       "license": "MIT",
       "devDependencies": {
         "@commitlint/cli": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tawk.to/nestjs-google-pubsub-microservice",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "NestJS Google Cloud Pub/Sub Microservice Transport",
   "author": "tawk.to",
   "license": "MIT",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the continuous integration environment to Node.js 20, ensuring improved compatibility.
  - Upgraded a key dependency to version 6.0.2 to maintain a reliable build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->