### PR TITLE
fix: Remove nestjs 9 from peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,9 +45,9 @@
       },
       "peerDependencies": {
         "@google-cloud/pubsub": "^3.0.0",
-        "@nestjs/common": "^9.0.0 || ^11.0.0",
-        "@nestjs/core": "^9.0.0 || ^11.0.0",
-        "@nestjs/microservices": "^9.0.0 || ^11.0.0",
+        "@nestjs/common": "^11.0.0",
+        "@nestjs/core": "^11.0.0",
+        "@nestjs/microservices": "^11.0.0",
         "reflect-metadata": "^0.1.13",
         "rxjs": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -66,9 +66,9 @@
   },
   "peerDependencies": {
     "@google-cloud/pubsub": "^3.0.0",
-    "@nestjs/common": "^9.0.0 || ^11.0.0",
-    "@nestjs/core": "^9.0.0 || ^11.0.0",
-    "@nestjs/microservices": "^9.0.0 || ^11.0.0",
+    "@nestjs/common": "^11.0.0",
+    "@nestjs/core": "^11.0.0",
+    "@nestjs/microservices": "^11.0.0",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.0.0"
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency requirements to enforce the use of the latest core library version (11.x or higher), enhancing compatibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->