### PR TITLE
fix: 🐛 (server) prevent uncaught exception on replyTo publish failure

### DIFF
--- a/lib/gc-pubsub.client.spec.ts
+++ b/lib/gc-pubsub.client.spec.ts
@@ -19,7 +19,9 @@ describe('GCPubSubClient', () => {
 
   beforeEach(() => {
     sandbox = sinon.createSandbox();
-    clock = sandbox.useFakeTimers();
+    clock = sandbox.useFakeTimers({
+      toFake: ['Date', 'setTimeout', 'clearTimeout'],
+    });
   });
 
   afterEach(() => {

--- a/lib/gc-pubsub.constants.ts
+++ b/lib/gc-pubsub.constants.ts
@@ -8,6 +8,7 @@ export const GC_PUBSUB_DEFAULT_INIT = true;
 export const GC_PUBSUB_DEFAULT_CHECK_EXISTENCE = true;
 export const GC_PUBSUB_DEFAULT_USE_ATTRIBUTES = false;
 export const ALREADY_EXISTS = 6;
+export const NOT_FOUND = 5;
 export const GC_PUBSUB_DEFAULT_AUTO_RESUME = false;
 export const GC_PUBSUB_DEFAULT_CREATE_SUBSCRIPTION_OPTIONS = {};
 export const GC_PUBSUB_CLIENT_PREFIX = 'gcpubsubclient:';

--- a/lib/gc-pubsub.server.spec.ts
+++ b/lib/gc-pubsub.server.spec.ts
@@ -309,6 +309,30 @@ describe('GCPubSubServer', () => {
         }),
       ).to.be.true;
     });
+
+    it('should log warn and not reject when reply topic is not found (NOT_FOUND)', async () => {
+      const notFoundError = Object.assign(new Error('Topic not found'), {
+        code: 5,
+      });
+      topicMock.publishMessage = sandbox.stub().rejects(notFoundError);
+
+      await server.sendMessage({ test: true }, 'missing-topic', '1');
+    });
+
+    it('should log error and not reject for generic publish errors', async () => {
+      const unavailableError = Object.assign(new Error('UNAVAILABLE'), {
+        code: 14,
+      });
+      topicMock.publishMessage = sandbox.stub().rejects(unavailableError);
+
+      await server.sendMessage({ test: true }, 'reply-topic', '2');
+    });
+
+    it('should log error and not reject when error has no code', async () => {
+      topicMock.publishMessage = sandbox.stub().rejects(new Error('boom'));
+
+      await server.sendMessage({ test: true }, 'reply-topic', '3');
+    });
   });
 
   describe('handleEvent', () => {

--- a/lib/gc-pubsub.server.ts
+++ b/lib/gc-pubsub.server.ts
@@ -35,6 +35,7 @@ import {
   GC_PUBSUB_DEFAULT_TOPIC,
   GC_PUBSUB_DEFAULT_CHECK_EXISTENCE,
   GC_PUBSUB_DEFAULT_ACK_AFTER_RESPONSE,
+  NOT_FOUND,
 } from './gc-pubsub.constants';
 import { GCPubSubContext } from './gc-pubsub.context';
 import { closePubSub, closeSubscription, flushTopic } from './gc-pubsub.utils';
@@ -258,18 +259,34 @@ export class GCPubSubServer extends Server implements CustomTransportStrategy {
 
     this.replyTopics.add(replyTo);
 
-    await this.client.topic(replyTo, this.publisherConfig).publishMessage({
-      data: outgoingResponse.data,
-      attributes: {
-        id,
-        ...attributes,
-        ...(outgoingResponse.isDisposed ? { isDisposed: '1' } : {}),
-        ...(outgoingResponse.err
-          ? { err: JSON.stringify(outgoingResponse.err) }
-          : {}),
-        ...(outgoingResponse.status ? { status: outgoingResponse.status } : {}),
-      },
-    });
+    try {
+      await this.client.topic(replyTo, this.publisherConfig).publishMessage({
+        data: outgoingResponse.data,
+        attributes: {
+          id,
+          ...attributes,
+          ...(outgoingResponse.isDisposed ? { isDisposed: '1' } : {}),
+          ...(outgoingResponse.err
+            ? { err: JSON.stringify(outgoingResponse.err) }
+            : {}),
+          ...(outgoingResponse.status
+            ? { status: outgoingResponse.status }
+            : {}),
+        },
+      });
+    } catch (err: any) {
+      if (err?.code === NOT_FOUND) {
+        this.logger.warn(
+          `Reply topic ${replyTo} not found; skipping reply for id ${id}`,
+        );
+      } else {
+        this.logger.error(
+          `Failed to publish reply to ${replyTo} for id ${id}: ${
+            err?.message ?? err
+          }`,
+        );
+      }
+    }
   }
 
   protected initializeSerializer(options: GCPubSubServerOptions): void {

--- a/tests/e2e/reply-publish-error.spec.ts
+++ b/tests/e2e/reply-publish-error.spec.ts
@@ -1,0 +1,118 @@
+import { PubSub, Subscription } from '@google-cloud/pubsub';
+import { expect } from 'chai';
+import { GCPubSubServer } from '../../lib';
+
+const ALREADY_EXISTS = 6;
+const apiEndpoint = 'localhost:8085';
+const projectId = 'test-project-id';
+const requestTopicName = 'reply-error-test-topic';
+const requestSubName = 'reply-error-test-sub';
+const validReplyTopicName = 'reply-error-test-valid-reply';
+const validReplySubName = 'reply-error-test-valid-reply-sub';
+
+async function ensureTopic(pubsub: PubSub, name: string) {
+  try {
+    await pubsub.topic(name).create();
+  } catch (err: any) {
+    if (err.code !== ALREADY_EXISTS) throw err;
+  }
+}
+
+async function ensureSubscription(
+  pubsub: PubSub,
+  topicName: string,
+  subName: string,
+) {
+  try {
+    await pubsub.topic(topicName).subscription(subName).create();
+  } catch (err: any) {
+    if (err.code !== ALREADY_EXISTS) throw err;
+  }
+}
+
+describe('GCPubSubServer reply publishing error handling', () => {
+  let pubServer: GCPubSubServer;
+  let pubsub: PubSub;
+  let replySubscription: Subscription;
+  let receivedReplies: Array<{ id: string }>;
+
+  beforeEach(async () => {
+    pubsub = new PubSub({ apiEndpoint, projectId });
+    receivedReplies = [];
+
+    await ensureTopic(pubsub, validReplyTopicName);
+    await ensureSubscription(pubsub, validReplyTopicName, validReplySubName);
+
+    replySubscription = pubsub.subscription(validReplySubName);
+    replySubscription.on('error', () => {});
+    replySubscription.on('message', (msg) => {
+      receivedReplies.push({ id: msg.attributes.id });
+      msg.ack();
+    });
+
+    pubServer = new GCPubSubServer({
+      topic: requestTopicName,
+      subscription: requestSubName,
+      client: { apiEndpoint, projectId },
+      init: true,
+    });
+
+    (pubServer as any).messageHandlers = new Map([
+      ['echo', async () => ({ ok: true })],
+    ]);
+
+    await new Promise<void>((resolve, reject) => {
+      pubServer.listen((err?: unknown) => (err ? reject(err) : resolve()));
+    });
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve) =>
+      replySubscription.close(() => resolve()),
+    );
+    await pubServer.close();
+    try {
+      await pubsub.subscription(validReplySubName).delete();
+    } catch {}
+    try {
+      await pubsub.subscription(requestSubName).delete();
+    } catch {}
+    try {
+      await pubsub.topic(validReplyTopicName).delete();
+    } catch {}
+    try {
+      await pubsub.topic(requestTopicName).delete();
+    } catch {}
+    await pubsub.close();
+  });
+
+  it('survives a missing reply topic and still serves subsequent valid requests', async () => {
+    await pubsub.topic(requestTopicName).publishMessage({
+      data: Buffer.from(JSON.stringify({ payload: 'first' })),
+      attributes: {
+        _id: 'bad-1',
+        _pattern: 'echo',
+        _replyTo: `definitely-does-not-exist-${Date.now()}`,
+      },
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    await pubsub.topic(requestTopicName).publishMessage({
+      data: Buffer.from(JSON.stringify({ payload: 'second' })),
+      attributes: {
+        _id: 'good-1',
+        _pattern: 'echo',
+        _replyTo: validReplyTopicName,
+      },
+    });
+
+    const deadline = Date.now() + 5000;
+    while (Date.now() < deadline) {
+      if (receivedReplies.some((r) => r.id === 'good-1')) return;
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+
+    expect.fail('Did not receive reply for good-1 within timeout');
+  }, 15000);
+});


### PR DESCRIPTION
Wrap reply publishMessage in try/catch — log warn for NOT_FOUND (reply topic gone), error otherwise. sendMessage no longer rejects, so the fire-and-forget call sites stop producing unhandled rejections.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for reply message publishing failures. The service now gracefully handles and logs failures instead of propagating them as unhandled exceptions, with differentiated logging strategies based on error type.

* **Tests**
  * Expanded test coverage for reply message publishing failure scenarios.
  * Added end-to-end test for validating reply message error handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->